### PR TITLE
'string-to-int' is obsoleted function

### DIFF
--- a/auto-package-update.el
+++ b/auto-package-update.el
@@ -91,7 +91,7 @@
 
 (defun apu-read-last-update-day ()
   "Read last update day."
-  (string-to-int
+  (string-to-number
    (apu--read-file-as-string apu-last-update-day-path)))
 
 ;;


### PR DESCRIPTION
It is obsoleted since Emacs 22.1(too old). We should not use it and use `string-to-number`
instead of it.
