### PR TITLE
Fix (auto-package-update-now)

### DIFF
--- a/auto-package-update.el
+++ b/auto-package-update.el
@@ -112,10 +112,11 @@
 (defun auto-package-update-now ()
   "Update installed Emacs packages."
   (interactive)
-  (package-refresh-contents)
 
+  (package-list-packages)
   (dolist (package-to-upgrade (package-menu--find-upgrades))
-    (package-install package-to-upgrade))
+    (package-install (car package-to-upgrade)))
+  (kill-buffer)
 
   (apu--write-current-day)
   (message "[PACKAGES UPDATED]"))


### PR DESCRIPTION
As stated in a comment in #6, (package-menu--find-upgrades) only works inside
the Package buffer opened by (package-list-packages).  The explicit call of
(package-refresh-contents) was also removed, because (package-list-packages)
does this automatically.
