### PR TITLE
Update auto-package-update.el

### DIFF
--- a/auto-package-update.el
+++ b/auto-package-update.el
@@ -156,7 +156,8 @@
       1))))
 
 (defun apu--package-up-to-date-p (package)
-  (when (package-installed-p package)
+  (when (and (package-installed-p package)
+	     (cadr (assq package package-archive-contents)))
     (let* ((newest-desc (cadr (assq package package-archive-contents)))
 	   (installed-desc (cadr (or (assq package package-alist)
 				     (assq package package--builtins))))


### PR DESCRIPTION
I have created several custom packages and installed them with M-x package-install-from-buffer.

These packages seem to have broken auto-package-update with an execution halting wrong-type error on line 159, as a nil was assigned to newest-desc in the let* instead of an arrayp.

This commit changes the behavior of apu such that an internal error is thrown when a package cannot be looked up (as it does not exist in the outside world -- but there's nothing wrong with that). This means apu updates the packages that do exist in external repos and issues a message like the following after all package updates have been attempted

Error installing unkillable-scratch

I do hope you find this commit useful, because I'd love to use the canonical apu instead of my fork to ensure I'm running any future updates. Great package!
