### PR TITLE
New feature: delete old version directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,16 @@ days but if you want to change it, all you need is:
 (setq auto-package-update-interval 14)
 ```
 
-Hooks
+To delete old version directory when updating, set to
+true variable `auto-package-update-delete-old-versions`. The
+default value is `nil`. If you want to enable deleting:
+
+```elisp
+(setq auto-package-update-delete-old-versions t)
+```
+
+### Hooks
+
 
 If you want to add functions to run *before* and *after* the package update, you can
 use the `auto-package-update-before-hook` and `auto-package-update-after-hook` hooks.

--- a/auto-package-update.el
+++ b/auto-package-update.el
@@ -225,9 +225,9 @@
   (-filter 'apu--package-out-of-date-p package-activated-list))
 
 (defun apu--add-to-old-versions-dirs-list (package)
-  "Add package old version dir to apu--old-versions-dir-list"
+  "Add package old version dir to apu--old-versions-dirs-list"
   (let ((desc (cadr (assq package package-alist))))
-    (concat apu--old-versions-dirs-list (package-desc-dir desc))))
+    (add-to-list 'apu--old-versions-dirs-list (package-desc-dir desc))))
 
 (defun apu--delete-old-versions-dirs-list ()
   (dolist (old-version-dir-to-delete apu--old-versions-dirs-list)

--- a/auto-package-update.el
+++ b/auto-package-update.el
@@ -82,7 +82,15 @@
 ;; (setq auto-package-update-interval 14)
 ;; ```
 ;;
-;;;; Hooks
+;; To delete residual old version directory when updating, set to
+;; true variable `auto-package-update-delete-old-versions`. The
+;; default value is `nil`. If you want to enable deleting:
+;;
+;; ```elisp
+;; (setq auto-package-update-delete-old-versions t)
+;; ```
+;;
+;;; Hooks
 ;;
 ;; If you want to add functions to run *before* and *after* the package update, you can
 ;; use the `auto-package-update-before-hook' and `auto-package-update-after-hook' hooks.

--- a/auto-package-update.el
+++ b/auto-package-update.el
@@ -145,7 +145,7 @@
   :type 'string
   :group 'auto-package-update)
 
-(defcustom apu--delete-old-versions
+(defcustom auto-package-update-delete-old-versions
   nil
   "If not nil, delete old versions directories."
   :type 'boolean
@@ -239,7 +239,7 @@
 (defun apu--safe-package-install (package)
   (condition-case ex
       (progn
-        (when apu--delete-old-versions
+        (when auto-package-update-delete-old-versions
           (apu--add-to-old-versions-dirs-list package))
         (package-install-from-archive (cadr (assoc package package-archive-contents)))
         (add-to-list 'apu--package-installation-results
@@ -251,7 +251,7 @@
   (let (apu--package-installation-results)
     (dolist (package-to-update packages)
       (apu--safe-package-install package-to-update))
-    (when apu--delete-old-versions
+    (when auto-package-update-delete-old-versions
       (apu--delete-old-versions-dirs-list))
     apu--package-installation-results))
 

--- a/auto-package-update.el
+++ b/auto-package-update.el
@@ -224,9 +224,16 @@
 (defun apu--packages-to-install ()
   (-filter 'apu--package-out-of-date-p package-activated-list))
 
+(defun apu--add-to-old-versions-dirs-list (package)
+  "Add package old version dir to apu--old-versions-dir-list"
+  (let ((desc (cadr (assq package package-alist))))
+    (concat apu--old-versions-dirs-list (package-desc-dir desc))))
+
 (defun apu--safe-package-install (package)
   (condition-case ex
       (progn
+        (when apu--delete-old-versions
+          (apu--add-to-old-versions-dirs-list package))
         (package-install-from-archive (cadr (assoc package package-archive-contents)))
         (add-to-list 'apu--package-installation-results
                      (format "%s up to date." (symbol-name package))))

--- a/auto-package-update.el
+++ b/auto-package-update.el
@@ -229,9 +229,9 @@
   (let ((desc (cadr (assq package package-alist))))
     (concat apu--old-versions-dirs-list (package-desc-dir desc))))
 
-(defun apu--delete-old-versions-dirs-list (dirs)
-  (dolist (old-version-dir-to-delete dirs)
-    (delete-directory old-version-dir-to-delete)))
+(defun apu--delete-old-versions-dirs-list ()
+  (dolist (old-version-dir-to-delete apu--old-versions-dirs-list)
+    (delete-directory old-version-dir-to-delete t)))
 
 (defun apu--safe-package-install (package)
   (condition-case ex

--- a/auto-package-update.el
+++ b/auto-package-update.el
@@ -109,7 +109,6 @@
 (require 'package)
 (package-initialize)
 
-
 ;;
 ;;; Customization
 ;;
@@ -149,7 +148,7 @@
 (defvar apu--last-update-day-path
   (expand-file-name apu--last-update-day-filename user-emacs-directory)
   "Path to the file that will hold the day in which the last update was run.")
-
+
 ;;
 ;;; File read/write helpers
 ;;
@@ -166,9 +165,9 @@
     (insert string)
     (when (file-writable-p file)
       (write-region (point-min)
-		    (point-max)
-		    file))))
-
+                    (point-max)
+                    file))))
+
 ;;
 ;;; Update day read/write functions
 ;;
@@ -185,7 +184,7 @@
   "Read last update day."
   (string-to-number
    (apu--read-file-as-string apu--last-update-day-path)))
-
+
 ;;
 ;;; Package update
 ;;
@@ -194,19 +193,19 @@
   (or
    (not (file-exists-p apu--last-update-day-path))
    (let* ((last-update-day (apu--read-last-update-day))
-	  (days-since (- (apu--today-day) last-update-day)))
+          (days-since (- (apu--today-day) last-update-day)))
      (>=
       (/ days-since auto-package-update-interval)
       1))))
 
 (defun apu--package-up-to-date-p (package)
   (when (and (package-installed-p package)
-	     (cadr (assq package package-archive-contents)))
+             (cadr (assq package package-archive-contents)))
     (let* ((newest-desc (cadr (assq package package-archive-contents)))
-	   (installed-desc (cadr (or (assq package package-alist)
-				     (assq package package--builtins))))
-	   (newest-version  (package-desc-version newest-desc))
-	   (installed-version (package-desc-version installed-desc)))
+           (installed-desc (cadr (or (assq package package-alist)
+                                     (assq package package--builtins))))
+           (newest-version  (package-desc-version newest-desc))
+           (installed-version (package-desc-version installed-desc)))
       (version-list-<= newest-version installed-version))))
 
 (defun apu--package-out-of-date-p (package)
@@ -218,13 +217,11 @@
 (defun apu--safe-package-install (package)
   (condition-case ex
       (progn
-	(package-install-from-archive (cadr (assoc package package-archive-contents)))
-	(add-to-list 'apu--package-installation-results
-		     (format "%s up to date."
-			     (symbol-name package))))
+        (package-install-from-archive (cadr (assoc package package-archive-contents)))
+        (add-to-list 'apu--package-installation-results
+                     (format "%s up to date." (symbol-name package))))
     ('error (add-to-list 'apu--package-installation-results
-			 (format "Error installing %s"
-				 (symbol-name package))))))
+                         (format "Error installing %s" (symbol-name package))))))
 
 (defun apu--safe-install-packages (packages)
   (let (apu--package-installation-results)

--- a/auto-package-update.el
+++ b/auto-package-update.el
@@ -230,8 +230,11 @@
     (add-to-list 'apu--old-versions-dirs-list (package-desc-dir desc))))
 
 (defun apu--delete-old-versions-dirs-list ()
+  "Delete package old version dirs saved in variable apu--old-versions-dirs-list"
   (dolist (old-version-dir-to-delete apu--old-versions-dirs-list)
-    (delete-directory old-version-dir-to-delete t)))
+    (delete-directory old-version-dir-to-delete t))
+  ;; Clear list
+  (setq apu--old-versions-dirs-list ()))
 
 (defun apu--safe-package-install (package)
   (condition-case ex

--- a/auto-package-update.el
+++ b/auto-package-update.el
@@ -155,6 +155,10 @@
   (expand-file-name apu--last-update-day-filename user-emacs-directory)
   "Path to the file that will hold the day in which the last update was run.")
 
+(defvar apu--old-versions-dirs-list
+  ()
+  "List with old versions directories to delete.")
+
 ;;
 ;;; File read/write helpers
 ;;

--- a/auto-package-update.el
+++ b/auto-package-update.el
@@ -229,6 +229,10 @@
   (let ((desc (cadr (assq package package-alist))))
     (concat apu--old-versions-dirs-list (package-desc-dir desc))))
 
+(defun apu--delete-old-versions-dirs-list (dirs)
+  (dolist (old-version-dir-to-delete dirs)
+    (delete-directory old-version-dir-to-delete)))
+
 (defun apu--safe-package-install (package)
   (condition-case ex
       (progn
@@ -244,6 +248,8 @@
   (let (apu--package-installation-results)
     (dolist (package-to-update packages)
       (apu--safe-package-install package-to-update))
+    (when apu--delete-old-versions
+      (apu--delete-old-versions-dirs-list))
     apu--package-installation-results))
 
 (defun apu--show-results-buffer (contents)

--- a/auto-package-update.el
+++ b/auto-package-update.el
@@ -145,6 +145,12 @@
   :type 'string
   :group 'auto-package-update)
 
+(defcustom apu--delete-old-versions
+  nil
+  "If not nil, delete old versions directories."
+  :type 'boolean
+  :group 'auto-package-update)
+
 (defvar apu--last-update-day-path
   (expand-file-name apu--last-update-day-filename user-emacs-directory)
   "Path to the file that will hold the day in which the last update was run.")

--- a/auto-package-update.el
+++ b/auto-package-update.el
@@ -222,7 +222,7 @@
   (not (apu--package-up-to-date-p package)))
 
 (defun apu--packages-to-install ()
-  (-filter 'apu--package-out-of-date-p package-activated-list))
+  (delete-dups (-filter 'apu--package-out-of-date-p package-activated-list)))
 
 (defun apu--add-to-old-versions-dirs-list (package)
   "Add package old version dir to apu--old-versions-dirs-list"


### PR DESCRIPTION
I have implemented a new feature: **delete old version directories when updating**. To acomplish this feature I have made the following changes:

I fix a little issue : the list contaning the packages to update had duplicates. To solve this I made this little change (5dc840ea6bf44ce433ed5995b399c79b3a93a496):
```elisp
(defun apu--packages-to-install ()
  (delete-dups (-filter 'apu--package-out-of-date-p package-activated-list)))
```

I define a variable `auto-package-update-delete-old-versions` that controls the feature's behaviour: when it is `nil`, the feature is ignored, other cases, the feature is applied.

I define a variable `apu--old-versions-dirs-list` that will save old version directory of every package that it is updated. 

To add the old version directory of `package` to this list, I implement `apu--add-to-old-versions-dirs-list`:
```elisp
(defun apu--add-to-old-versions-dirs-list (package)
  "Add package old version dir to apu--old-versions-dirs-list"
  (let ((desc (cadr (assq package package-alist))))
    (add-to-list 'apu--old-versions-dirs-list (package-desc-dir desc))))
```
This function is invocated everytime that a package is installed:
```elisp
(defun apu--safe-package-install (package)
  ...
        (when auto-package-update-delete-old-versions
          (apu--add-to-old-versions-dirs-list package))
        (package-install-from-archive (cadr (assoc package package-archive-contents)))
  ...
```

To delete old version directories of the list when all package are updated, I implement `apu--delete-old-versions-dirs-list`:

```elisp
(defun apu--delete-old-versions-dirs-list ()
  "Delete package old version dirs saved in variable apu--old-versions-dirs-list"
  (dolist (old-version-dir-to-delete apu--old-versions-dirs-list)
    (delete-directory old-version-dir-to-delete t))
  ;; Clear list
  (setq apu--old-versions-dirs-list ()))
```
This function is invocated after all packages have been updated:
```elisp
 (defun apu--safe-install-packages (packages)
   (let (apu--package-installation-results)
     (dolist (package-to-update packages)
       (apu--safe-package-install package-to-update))
     (when auto-package-update-delete-old-versions
       (apu--delete-old-versions-dirs-list))
     apu--package-installation-results))
```

Finally, I update the documentation including this new feature (ec2c83ec7eaf2d3b169ea7ae1c8b341707b085b5), along with some code indentation fix (fd8a1c1dff4438cfb52405984a47ce3f67487a29) and a minor documentation fix (ec2c83ec7eaf2d3b169ea7ae1c8b341707b085b5).

Any questions and suggestions are welcome.