### PR TITLE
Replace deprecated toggle-read-only with read-only-mode

### DIFF
--- a/auto-package-update.el
+++ b/auto-package-update.el
@@ -269,7 +269,7 @@
     (pop-to-buffer auto-package-update-buffer-name)
     (erase-buffer)
     (insert contents)
-    (toggle-read-only 1)
+    (read-only-mode 1)
     (auto-package-update-minor-mode 1)))
 
 (define-minor-mode auto-package-update-minor-mode


### PR DESCRIPTION
'read-only-mode' should be used instead of toggle-read-only
since Emacs 24.3.

This causes byte-compile warning.

```
auto-package-update.el:271:13:Warning: `toggle-read-only' is an obsolete          
    function (as of 24.3); use `read-only-mode' instead.
```