### PR TITLE
Remove second dash from apu--last-update-day-path

### DIFF
--- a/auto-package-update.el
+++ b/auto-package-update.el
@@ -151,7 +151,7 @@
   :type 'hook
   :group 'auto-package-update)
 
-(defcustom apu--last-update-day-filename
+(defcustom apu-last-update-day-filename
   ".last-package-update-day"
   "Name of the file in which the last update day is going to be stored."
   :type 'string
@@ -176,7 +176,7 @@
   :group 'auto-package-update)
 
 (defvar apu--last-update-day-path
-  (expand-file-name apu--last-update-day-filename user-emacs-directory)
+  (expand-file-name apu-last-update-day-filename user-emacs-directory)
   "Path to the file that will hold the day in which the last update was run.")
 
 (defvar apu--old-versions-dirs-list

--- a/tests/auto-package-update-test.el
+++ b/tests/auto-package-update-test.el
@@ -1,7 +1,7 @@
 (require 'auto-package-update)
 
 (ert-deftest test-should-update-if-there-is-no-record-file ()
-  (setq apu--last-update-day-path "/I/be/no/file")
+  (setq apu-last-update-day-path "/I/be/no/file")
   (should (apu--should-update-packages-p)))
 
 (ert-deftest test-dash-filter-usage ()


### PR DESCRIPTION
It is treated like a user customizable variable in the code and tests
but is not named as such. Closes #31 