### PR TITLE
Add an option to hide the results buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ default value is `nil`. If you want to enable deleting:
 (setq auto-package-update-delete-old-versions t)
 ```
 
+By default the results buffer will be shown after auto package update is complete.
+Set to true for variable `auto-package-update-hide-results` to hide the results buffer
+after auto package update is complete:
+
+```elisp
+(setq auto-package-update-hide-results t)
+```
+
 ### Hooks
 
 

--- a/auto-package-update.el
+++ b/auto-package-update.el
@@ -175,6 +175,13 @@
   :type 'boolean
   :group 'auto-package-update)
 
+(defcustom auto-package-update-hide-results
+  nil
+  "If not nil, the result of auto package update in buffer
+`auto-package-update-buffer-name' will not be shown."
+  :type 'boolean
+  :group 'auto-package-update)
+
 (defvar apu--last-update-day-path
   (expand-file-name apu--last-update-day-filename user-emacs-directory)
   "Path to the file that will hold the day in which the last update was run.")
@@ -228,7 +235,7 @@
    (or
     (not (file-exists-p apu--last-update-day-path))
     (let* ((last-update-day (apu--read-last-update-day))
-	   (days-since (- (apu--today-day) last-update-day)))
+           (days-since (- (apu--today-day) last-update-day)))
       (>=
        (/ days-since auto-package-update-interval)
        1)))
@@ -287,9 +294,14 @@
       (apu--delete-old-versions-dirs-list))
     apu--package-installation-results))
 
-(defun apu--show-results-buffer (contents)
+(defun apu--write-results-buffer (contents)
   (let ((inhibit-read-only t))
-    (pop-to-buffer auto-package-update-buffer-name)
+    (if (not auto-package-update-hide-results)
+        (pop-to-buffer auto-package-update-buffer-name)
+      (set-buffer
+       (get-buffer-create auto-package-update-buffer-name))
+      (bury-buffer
+       auto-package-update-buffer-name))
     (erase-buffer)
     (insert contents)
     (read-only-mode 1)
@@ -310,9 +322,10 @@
 
   (let ((installation-report (apu--safe-install-packages (apu--packages-to-install))))
     (apu--write-current-day)
-    (apu--show-results-buffer (mapconcat #'identity
-                                         (cons "[PACKAGES UPDATED]:" installation-report)
-                                         "\n")))
+    (apu--write-results-buffer
+     (mapconcat #'identity
+                (cons "[PACKAGES UPDATED]:" installation-report)
+                "\n")))
 
   (run-hooks 'auto-package-update-after-hook))
 


### PR DESCRIPTION
Sometimes I do not want the results buffer to be showing up automatically after auto package update is done just to avoid distraction. So I added an option `auto-package-update-hide-results` to hide and bury the results buffer.