### PR TITLE
Add setting to show preview of outdated packages when prompting

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ Use this setting to show a manual prompt before automatic updates:
 (setq auto-package-update-prompt-before-update t)
 ```
 
+In addition to this you can use the following setting to get a preview
+together with the prompt, with a list of all packages that are going
+to be updated:
+
+```elisp
+(setq auto-package-update-show-preview t)
+```
+
 To delete residual old version directory when updating, set to
 true variable `auto-package-update-delete-old-versions`. The
 default value is `nil`. If you want to enable deleting:


### PR DESCRIPTION
This PR adds the `auto-package-update-show-preview` setting to show a buffer with the list of packages to be upgraded when prompting the user due to `auto-package-update-prompt-before-update`. This allows users to better decide whether to perform an upgrade or not, depending on the affected packages.

If the setting is enabled and all packages are up-to-date, there will be no prompt (since it would be a noop) but only the preview buffer stating that all packages are up to date.

Here is how it looks with updates available:
<img width="594" alt="image" src="https://user-images.githubusercontent.com/66047/116467077-946deb80-a86f-11eb-982f-9f6992a91b2c.png">
