### PR TITLE
Add ability to exclude specific packages from automatic updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,15 @@ after auto package update is complete:
 (setq auto-package-update-hide-results t)
 ```
 
+By default all activated packages are eligible for automatic updates.  However, packages
+can be excluded from this automated process.  Packages added to the exclusion list will
+not be considered for automatic updates.  These packages can still be manually updated
+as desired.
+
+``` elisp
+(setq auto-package-update-excluded-packages '(magit ivy))
+```
+
 ### Hooks
 
 

--- a/auto-package-update.el
+++ b/auto-package-update.el
@@ -183,6 +183,12 @@
   :type 'boolean
   :group 'auto-package-update)
 
+(defcustom auto-package-update-excluded-packages
+  nil
+  "List of packages to exclude from automatic package update."
+  :type '(repeat symbol)
+  :group 'auto-package-update)
+
 (defvar auto-package-update-last-update-day-path
   (expand-file-name auto-package-update-last-update-day-filename user-emacs-directory)
   "Path to the file that will hold the day in which the last update was run.")
@@ -262,7 +268,9 @@
   (not (apu--package-up-to-date-p package)))
 
 (defun apu--packages-to-install ()
-  (delete-dups (-filter 'apu--package-out-of-date-p package-activated-list)))
+  (delete-dups (-filter 'apu--package-out-of-date-p
+                        (-difference package-activated-list
+                                     auto-package-update-excluded-packages))))
 
 (defun apu--add-to-old-versions-dirs-list (package)
   "Add package old version dir to apu--old-versions-dirs-list"


### PR DESCRIPTION
This PR adds the `auto-package-update-excluded-packages` setting to prevent user specified packages from being automatically updated.  This can be useful if a package needs to stay at a specific version but you'd like to upgrade other packages.