### PR TITLE
Async update and minor changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        emacs_version:
+          - 27.1
+          - snapshot
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: purcell/setup-emacs@master
+      with:
+        version: ${{ matrix.emacs_version }}
+
+    - run: make test

--- a/auto-package-update.el
+++ b/auto-package-update.el
@@ -79,7 +79,14 @@
 ;; (package-refresh-contents :async)
 ;; ```
 ;;
-;; we won't get all packages updated.
+;; we won't get all packages updated. The best practice is
+;;
+;; ```elisp
+;; M-x package-refresh-contents
+;; ```
+;;
+;; first, then use `auto-package-update-now-async'. Note, it's not 100% async,
+;; byte compiling packages can still block Emacs.
 
 ;;; Customization:
 ;;

--- a/auto-package-update.el
+++ b/auto-package-update.el
@@ -184,7 +184,8 @@
 
 (defcustom auto-package-update-show-preview
   nil
-  "If not nil, show the list of packages to be updated when prompting before running auto-package-update-maybe"
+  "If not nil, show the list of packages to be updated when
+prompting before running auto-package-update-maybe"
   :type 'boolean
   :group 'auto-package-update)
 
@@ -338,9 +339,13 @@
   :group 'auto-package-update
   :keymap '(("q" . quit-window)))
 
+;; Silence byte compile warnings.
+(defvar quelpa-cache)
+(declare-function quelpa-read-cache "quelpa" ())
+
 (defun apu--filter-quelpa-packages (package-list)
   "Return PACKAGE-LIST without quelpa packages."
-  (if (fboundp 'quelpa)
+  (if (require 'quelpa nil t)
       (let ((filtered-package-list package-list))
         (quelpa-read-cache)
         (dolist (package quelpa-cache)
@@ -391,8 +396,9 @@
 
 ;;;###autoload
 (defun auto-package-update-maybe ()
-  "Update installed Emacs packages if at least \
-`auto-package-update-interval' days have passed since the last update."
+  "Update installed Emacs packages if at least
+`auto-package-update-interval' days have passed since the last
+update."
   (when (apu--should-update-packages-p)
     (auto-package-update-now)))
 


### PR DESCRIPTION
- A new command `auto-package-update-now-async` is added
- GitHub Actions integration
- Use `lexical-binding`
- Suppress several compile-warnings (Emacs 28 complains the docstring is wider than 80 characters)
- better `quelpa` integration

Since function `quelpa` can be `autoload`ed, `(fboundp 'quelpa)` returning t doesn't mean other quelpa functions is ready to use.